### PR TITLE
Add plugin.toml

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+name = "dokku-slack"
+description = "Dokku plugin to notify a Slack room on deployment"
+version = "0.1.0"
+website_url = "https://github.com/lmars/dokku-slack"
+[plugin.config]


### PR DESCRIPTION
Guessed at the version number, but this should let the plugin list correctly when `dokku plugin:list` is used in Dokku 0.8.x etc.